### PR TITLE
added ids as argument and simplified api

### DIFF
--- a/src/elabftwcontrol/__init__.py
+++ b/src/elabftwcontrol/__init__.py
@@ -1,0 +1,17 @@
+from elabftwcontrol._logging import set_log_level
+from elabftwcontrol.download.api import (
+    get_experiment_templates_as_df,
+    get_experiments_as_df,
+    get_item_types_as_df,
+    get_items_as_df,
+)
+from elabftwcontrol.global_config import connect
+
+__all__ = [
+    "get_experiment_templates_as_df",
+    "get_experiments_as_df",
+    "get_item_types_as_df",
+    "get_items_as_df",
+    "connect",
+    "set_log_level",
+]

--- a/src/elabftwcontrol/_logging.py
+++ b/src/elabftwcontrol/_logging.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+
+from elabftwcontrol.defaults import DEFAULT_LOG_LEVEL
+
+logging.basicConfig(stream=sys.stderr)
+
+logger = logging.getLogger("elabftwcontrol")
+logger.setLevel(DEFAULT_LOG_LEVEL)
+
+
+def set_log_level(
+    level: str,
+) -> None:
+    logger.setLevel(level)

--- a/src/elabftwcontrol/defaults.py
+++ b/src/elabftwcontrol/defaults.py
@@ -1,10 +1,5 @@
 import logging
-import sys
 from pathlib import Path
 
 DEFAULT_CONFIG_FILE = Path.home() / ".elabftwcontrol.json"
-
-logging.basicConfig(stream=sys.stderr)
-
-logger = logging.getLogger("elabftwcontrol")
-logger.setLevel(logging.WARN)
+DEFAULT_LOG_LEVEL = logging.INFO

--- a/src/elabftwcontrol/download/__init__.py
+++ b/src/elabftwcontrol/download/__init__.py
@@ -1,12 +1,10 @@
 from elabftwcontrol.download.api import (
     IngestConfiguration,
     IngestJob,
-    MetadataColumns,
     ObjectTypes,
     OutputFormats,
     TableCellContentType,
     TableShapes,
-    TableTypes,
 )
 
 __all__ = [
@@ -16,6 +14,4 @@ __all__ = [
     "OutputFormats",
     "ObjectTypes",
     "TableShapes",
-    "TableTypes",
-    "MetadataColumns",
 ]

--- a/src/elabftwcontrol/download/metadata.py
+++ b/src/elabftwcontrol/download/metadata.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Callable, NamedTuple, Optional, TypeVar, Union
 
-from elabftwcontrol.defaults import logger
+from elabftwcontrol._logging import logger
 
 T = TypeVar("T")
 V = TypeVar("V")

--- a/src/elabftwcontrol/global_config.py
+++ b/src/elabftwcontrol/global_config.py
@@ -1,0 +1,81 @@
+from typing import Optional
+
+from elabftwcontrol._logging import logger
+from elabftwcontrol.client import ElabftwApi
+
+
+class GlobalConfig:
+    """A class to make it to configure and store a global connection instead of being forced to always create and pass a client"""
+
+    _client: Optional[ElabftwApi] = None
+
+    @classmethod
+    def get_client(
+        cls,
+    ) -> ElabftwApi:
+        if cls._client is None:
+            raise RuntimeError(
+                "No connection has been configured. Please use the `elabftwcontrol.connect` "
+                "function to set up a connection."
+            )
+        return cls._client
+
+    @classmethod
+    def configure_client(
+        cls,
+        profile: str = "default",
+        host_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        verify_ssl: Optional[bool] = None,
+    ) -> None:
+        if host_url is not None:
+            client = ElabftwApi.new(
+                host_url=host_url,
+                api_key=api_key,
+                verify_ssl=verify_ssl,
+            )
+        else:
+            logger.info(f"No host url configured, trying to use profile: {profile}")
+            try:
+                client = ElabftwApi.from_config_file(profile=profile)
+            except KeyError:
+                raise RuntimeError(
+                    f"Profile `{profile}` is not configured. Use `elabftwctl config` "
+                    "on the command line to set up a new profile."
+                )
+            except Exception as e:
+                raise RuntimeError(f"Unexpected error: {e}")
+        cls._client = client
+
+    @classmethod
+    def reset_client(
+        cls,
+    ) -> None:
+        cls._client = None
+
+    @classmethod
+    def test_connection(cls) -> None:
+        client = cls.get_client()
+        info = client.info
+        try:
+            info.get_info()
+        except Exception as e:
+            raise RuntimeError(f"Could not establish connection to eLabFTW: {e}")
+        logger.info(f"Succesfully connected to eLabFTW host: {client.host_name}")
+
+
+def connect(
+    profile: str = "default",
+    host_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    verify_ssl: Optional[bool] = None,
+    test_connection: bool = True,
+) -> None:
+    GlobalConfig.configure_client(
+        profile=profile,
+        host_url=host_url,
+        api_key=api_key,
+        verify_ssl=verify_ssl,
+    )
+    if test_connection:
+        GlobalConfig.test_connection()

--- a/src/elabftwcontrol/models.py
+++ b/src/elabftwcontrol/models.py
@@ -34,7 +34,7 @@ from pydantic import (
 )
 
 from elabftwcontrol.client import ElabftwApi, ObjectSyncer
-from elabftwcontrol.defaults import logger
+from elabftwcontrol._logging import logger
 from elabftwcontrol.types import EntityTypes, SingleObjectTypes, StringAble
 from elabftwcontrol.utils import (
     parse_optional_date,

--- a/src/elabftwcontrol/s3_utils.py
+++ b/src/elabftwcontrol/s3_utils.py
@@ -14,7 +14,7 @@ except ImportError:
     S3_ENABLED = False
 
 
-from elabftwcontrol.defaults import logger
+from elabftwcontrol._logging import logger
 
 
 class ParsedS3Path(NamedTuple):

--- a/src/elabftwcontrol/upload/manifests.py
+++ b/src/elabftwcontrol/upload/manifests.py
@@ -24,7 +24,7 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from elabftwcontrol.defaults import logger
+from elabftwcontrol._logging import logger
 from elabftwcontrol.models import ExtraFieldData, SingleFieldData
 from elabftwcontrol.upload.graph import DependencyGraph
 

--- a/src/elabftwcontrol/upload/parsers.py
+++ b/src/elabftwcontrol/upload/parsers.py
@@ -4,7 +4,7 @@ from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, NamedTuple, Sequence, Union
 
-from elabftwcontrol.defaults import logger
+from elabftwcontrol._logging import logger
 from elabftwcontrol.upload.manifests import ElabObjManifests, ManifestIndex
 from elabftwcontrol.utils import read_yaml
 

--- a/src/elabftwcontrol/upload/planning.py
+++ b/src/elabftwcontrol/upload/planning.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from typing import Dict, Iterable, List, Literal, NamedTuple, Sequence
 
 from elabftwcontrol.client import ObjectSyncer
-from elabftwcontrol.defaults import logger
+from elabftwcontrol._logging import logger
 from elabftwcontrol.graph import DependencyGraph
 from elabftwcontrol.manifests import Node, ObjectManifest, StateDefinition
 from elabftwcontrol.parsers import ParsedProject


### PR DESCRIPTION
In this PR:
* allow filtering based on object IDs in download
* added a couple helper functions in the client
* swapped out some CLI arguments for simpler to understand options. Also added "library function equivalent" functions in `download.api` to get equivalent pandas dataframes in another program. To make this as easy as possible, it is also possible now to configure a "global" client, which avoids having to pass this object into every function call.